### PR TITLE
Switched to dev branch of swift SDK

### DIFF
--- a/custom-sign-in/OktaNativeLogin/NativeSignInViewController.swift
+++ b/custom-sign-in/OktaNativeLogin/NativeSignInViewController.swift
@@ -140,7 +140,7 @@ extension NativeSignInViewController: AuthenticationClientMFAHandler {
             },
             cancel: { [weak self] in
                 self?.hideProgress()
-                self?.client.cancel()
+                self?.client.cancelTransaction()
             }
         )
     }

--- a/custom-sign-in/Podfile
+++ b/custom-sign-in/Podfile
@@ -3,5 +3,5 @@ use_frameworks!
 
 target 'OktaNativeLogin' do
   pod 'OktaAuth', :git => 'git@github.com:okta/okta-sdk-appauth-ios.git', :branch => 'dev'
-  pod 'OktaAuthNative', :git => 'https://github.com/okta/okta-auth-swift.git', :branch => 'mfa+pods'
+  pod 'OktaAuthNative', :git => 'git@github.com:okta/okta-auth-swift.git', :branch => 'dev'
 end


### PR DESCRIPTION
### Problem Analysis (Technical)
Previously we used test branch for Swift sdk dependency since mea and Cocoapods support wasn't implemented in dev branch.

### Solution (Technical)
Use dev branch for dependency until Swift SDK is released to Cocoapods.

### Affected Components
Samples IOS

### Tests
N/A