### PR TITLE
OKTA-789927: Move away from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  platform-helpers-general: okta/general-platform-helpers@1.8
+  platform-helpers-general: okta/general-platform-helpers@1.9
 
 executors:
   apple-ci-arm-medium:
@@ -39,20 +39,14 @@ jobs:
 workflows:
   semgrep:
     jobs:
-      - platform-helpers-general/job-semgrep-prepare:
-          name: semgrep-prepare
-          filters:
-            branches:
-              only:
-                - master
       - platform-helpers-general/job-semgrep-scan:
           name: semgrep-scan
           filters:
             branches:
               only:
                 - master
-          requires:
-            - semgrep-prepare
+          context:
+            - static-analysis
   security-scan:
     jobs:
       - setup:
@@ -60,19 +54,13 @@ workflows:
             branches:
               only:
                 - master
-      - platform-helpers-general/job-snyk-prepare:
-          name: prepare-snyk
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - setup
       - snyk-scan:
           name: execute-snyk
           filters:
             branches:
               only:
                 - master
+          context:
+            - static-analysis
           requires:
-            - prepare-snyk
+            - setup


### PR DESCRIPTION
This moves away from orb-defined jobs when running static analysis tooling.